### PR TITLE
Improve heavy-particle inelastic forward-scattering integral accuracy.

### DIFF
--- a/src/cross_sections/feed.jl
+++ b/src/cross_sections/feed.jl
@@ -54,34 +54,67 @@ if is_dirac Np = 1; u = [0]; w = [2] else u,w = quadrature(Np,q_type) end
 # Feed function over all groups and under the cutoff energy
 #----
 
+# Heavy inelastic S (same scattered particle)
+is_heavy_inelastic_S = (is_proton(incoming_particle) || is_alpha(incoming_particle)) && (incoming_particle == scattered_particle)
+
 # Loop over the coumpound elements
 Nz = length(Z)
 for i in range(1,Nz)
 
-    # Loop over subshells
+    nd = nuclei_density(Z[i],ρ) * ωz[i]
+
+    # Loop over subshells and outgoing groups
     Nshells,Zi,Ui,Ti,ri,_ = electron_subshells(Z[i],~is_subshells)
     for gf in range(1,Ng), δi in range(1,Nshells)
-        
+
         # Final energy group
         Ef⁻ = Eout[gf]; Ef⁺ = Eout[gf+1]
         Ef⁻,Ef⁺,isSkip = bounds_dispatch(interaction,Ef⁻,Ef⁺,Ei,gi,gf,type,Ui[δi],Ec,incoming_particle)
         if isSkip continue end
         ΔEf = Ef⁻ - Ef⁺
-        
+
         # Integration over the energy group
         𝓕i = zeros(L+1)
         𝓕iₑ = 0
+
+        # For heavy particles, compute the analytic singular contribution once per group
+        analytic_A = 0.0
+        M₁ = 0.0
+        cache = nothing
+        if is_heavy_inelastic_S
+            cache = HeavyInelasticCache(Zi[δi], Ei, incoming_particle)
+            analytic_A = integrate_A_over_W2_per_subshell(cache, Ef⁻, Ef⁺) * nd
+            M₁ = feed_first_moment_heavy_particle(cache, Ef⁻, Ef⁺) * nd
+        end
+
+        # Quadrature integration (regular remainder for heavy particles, full for others)
         for n in range(1,Np)
 
             # Outgoing particle energy group
             if (is_elastic) Ef = Ei else Ef = (u[n]*ΔEf + (Ef⁻+Ef⁺))/2 end
 
             # Compute Legendre angular flux moments
-            Σsᵢ = ΔEf .* w[n]/2 .* dcs_dispatch(interaction,L,Ei,Ef,Z[i],scattered_particle,type,i,particles,Ein,Ef⁻,Ef⁺,δi,Ui[δi],Zi[δi],Ti[δi],ri[δi],Ec,incoming_particle) * nuclei_density(Z[i],ρ) * ωz[i]
+            Σsᵢ = ΔEf .* w[n]/2 .* dcs_dispatch(interaction,L,Ei,Ef,Z[i],scattered_particle,type,i,particles,Ein,Ef⁻,Ef⁺,δi,Ui[δi],Zi[δi],Ti[δi],ri[δi],Ec,incoming_particle) * nd
             if is_dirac Σsᵢ /= ΔEf  end
             𝓕i .+= Σsᵢ
-            𝓕iₑ += Σsᵢ[1] * (Ef+ΔQ)
+            𝓕iₑ += Σsᵢ[1] * (Ef + ΔQ)
+        end
 
+        # Add analytic singular contribution for heavy particles
+        if is_heavy_inelastic_S
+            𝓕i .+= analytic_A .* ones(L+1)
+            for l in range(0,L)
+                𝓕i[l+1] += integrate_leading_1overW_per_subshell(cache, Ef⁻, Ef⁺, l) * nd
+            end
+            σ_analytic = feed_analytical_heavy_particle(cache, Ef⁻, Ef⁺) * nd
+            𝓕iₑ = Ei * σ_analytic - M₁
+
+            # Consistency check: ensure analytic σ equals numeric l=0 moment
+            if ~isapprox(𝓕i[1], σ_analytic; rtol=1e-3, atol=1e-12)
+                rel = abs(𝓕i[1] - σ_analytic) / max(abs(σ_analytic), 1e-300)
+                @warn "Heavy inelastic feed: analytic/numeric mismatch" Z=Z[i] δi=δi gf=gf σ_analytic=σ_analytic numeric_l0=𝓕i[1] rel_diff=rel
+                𝓕i[1] = σ_analytic
+            end
         end
         𝓕[gf,:] .+= 𝓕i
         𝓕ₑ[gf] += 𝓕iₑ

--- a/src/cross_sections/inelastic_collision_heavy_particle.jl
+++ b/src/cross_sections/inelastic_collision_heavy_particle.jl
@@ -1,16 +1,79 @@
 """
-    inelastic_collision_heavy_particle(Ei::Float64,W::Float64,particle::Particle)
+    HeavyInelasticCache
+
+Stores reusable constants for heavy-particle inelastic collisions with one subshell
+electron population at one incident energy.
+
+# Field(s)
+- `Zi::Float64` : number of electrons in the subshell.
+- `Ei::Float64` : incoming particle energy [in m_e*c^2].
+- `mₑ::Float64` : electron rest energy [MeV].
+- `rₑ::Float64` : classical electron radius [cm].
+- `Zc::Float64` : incoming particle charge.
+- `ratio_mass::Float64` : incoming particle mass divided by the electron rest mass.
+- `γ::Float64` : Lorentz factor of the incoming particle.
+- `β²::Float64` : squared reduced speed of the incoming particle.
+- `R::Float64` : recoil factor used in the maximum energy transfer.
+- `W_ridge::Float64` : maximum reduced energy transfer.
+- `A::Float64` : leading cross-section coefficient.
+- `mu_lin::Float64` : coefficient used in the angular small-energy-transfer expansion.
+"""
+struct HeavyInelasticCache
+    Zi::Float64
+    Ei::Float64
+    mₑ::Float64
+    rₑ::Float64
+    Zc::Float64
+    ratio_mass::Float64
+    γ::Float64
+    β²::Float64
+    R::Float64
+    W_ridge::Float64
+    A::Float64  # 2*π*rₑ^2/β² * Zc^2 * Zi
+    mu_lin::Float64  # For angular derivatives: 1 / (Ei * (Ei + 2*ratio_mass))
+end
+
+"""
+    HeavyInelasticCache(Zi::Real, Ei::Float64, particle::Particle)
+
+Builds a cache of heavy-particle inelastic-collision constants.
+
+# Input Argument(s)
+- `Zi::Real` : number of electrons in the subshell.
+- `Ei::Float64` : incoming particle energy [in m_e*c^2].
+- `particle::Particle` : incoming heavy charged particle.
+
+# Output Argument(s)
+- `cache::HeavyInelasticCache` : reusable constants for cross-section and feed integrations.
+"""
+function HeavyInelasticCache(Zi::Real, Ei::Float64, particle::Particle)
+    mₑ = 0.51099895069
+    rₑ = 2.81794092e-13
+    Zc = get_charge(particle)
+    ratio_mass = get_mass(particle)/mₑ
+    γ = (Ei + ratio_mass)/ratio_mass
+    β² = (γ^2-1)/γ^2
+    R = 1/(1+(1/ratio_mass)^2+2*γ/ratio_mass)
+    W_ridge = 2*β²*γ^2*R
+    A = 2*π*rₑ^2/β² * Zc^2 * Zi
+    mu_lin = 1.0 / (Ei * (Ei + 2.0 * ratio_mass))
+    return HeavyInelasticCache(Float64(Zi), Ei, mₑ, rₑ, Zc, ratio_mass, γ, β², R, W_ridge, A, mu_lin)
+end
+
+"""
+    inelastic_collision_heavy_particle(Zi::Real, Ei::Float64, W::Float64,
+    particle::Particle)
 
 Gives the inelastic differential cross-sections with atomic electrons for heavy particles.
 
 # Input Argument(s)
 - `Zi::Real` : number of electron(s).
-- `Ei::Float64` : incoming particle energy.
-- `W::Float64` : energy lost by the positron.
+- `Ei::Float64` : incoming particle energy [in m_e*c^2].
+- `W::Float64` : energy transferred to the atomic electron [in m_e*c^2].
+- `particle::Particle` : incoming heavy charged particle.
 
 # Output Argument(s)
-- `σs::Float64` : inelastic differential cross-sections with atomic electrons for heavy
-  particles.
+- `σs::Float64` : inelastic differential cross-section with atomic electrons for heavy particles.
 
 # Reference(s)
 - Salvat and Heredia (2024), Electromagnetic interaction models for Monte-Carlo simulation
@@ -38,9 +101,202 @@ function inelastic_collision_heavy_particle(Zi::Real,Ei::Float64,W::Float64,part
     if W_ridge > W
         σs = 2*π*rₑ^2/β² * Zc^2 * Zi * 1/W^2 * (1 - β²*W/W_ridge + (1-β²)/(2*ratio_mass^2)*W^2)
     end
+
     return σs
 end
 
+"""
+    heavy_sigma_components(cache::HeavyInelasticCache, W::Float64)
+
+Splits the heavy-particle inelastic differential cross-section into its singular
+`A / W^2` part and the remaining regular part.
+
+# Input Argument(s)
+- `cache::HeavyInelasticCache` : reusable constants for this subshell and particle.
+- `W::Float64` : energy transferred to the atomic electron [in m_e*c^2].
+
+# Output Argument(s)
+- `sigma_reg::Float64` : regular contribution, equal to `sigma_full(W) - A / W^2`.
+- `A_over_W2::Float64` : leading singular contribution.
+"""
+function heavy_sigma_components(cache::HeavyInelasticCache, W::Float64)
+    if W <= 0
+        return 0.0, 0.0
+    end
+    if W > cache.W_ridge
+        return 0.0, 0.0
+    end
+
+    # Full sigma
+    σ_full = cache.A * (1/W^2) * (1 - cache.β²*W/cache.W_ridge + (1 - cache.β²)/(2*cache.ratio_mass^2)*W^2)
+
+    A_over_W2 = cache.A / W^2
+    sigma_reg = σ_full - A_over_W2
+    return sigma_reg, A_over_W2
+end
+
+"""
+    integrate_A_over_W2_per_subshell(cache::HeavyInelasticCache,
+    Ef_minus::Float64, Ef_plus::Float64)
+
+Integrates the leading `A / W^2` part analytically over an outgoing-energy group.
+The integration bounds are converted with `W = Ei - Ef` and clipped to
+`0 < W <= W_ridge`.
+
+# Input Argument(s)
+- `cache::HeavyInelasticCache` : reusable constants for this subshell and particle.
+- `Ef_minus::Float64` : upper bound of the outgoing particle energy group [in m_e*c^2].
+- `Ef_plus::Float64` : lower bound of the outgoing particle energy group [in m_e*c^2].
+
+# Output Argument(s)
+- `σ::Float64` : integral of `A / W^2` over the clipped group.
+"""
+function integrate_A_over_W2_per_subshell(cache::HeavyInelasticCache, Ef_minus::Float64, Ef_plus::Float64)
+    # Energy bounds in W = Ei - Ef
+    W_plus = cache.Ei - Ef_plus
+    W_minus = cache.Ei - Ef_minus
+
+    # Clip to (0, W_ridge]
+    W_lo = max(W_minus, 1e-300)
+    W_hi = min(W_plus, cache.W_ridge)
+    if W_hi <= W_lo
+        return 0.0
+    end
+
+    # Numerically stable form: (1/W_lo - 1/W_hi) = (W_hi - W_lo) / (W_lo * W_hi)
+    ΔW_clip = W_hi - W_lo
+    if ΔW_clip <= 0.0
+        return 0.0
+    end
+    denom = W_lo * W_hi
+    # Guard against underflow/overflow by ensuring denom is not subnormal
+    if denom == 0.0
+        # If one bound is effectively zero, return the dominant 1/W_lo term
+        return cache.A * (1.0 / W_lo)
+    end
+    return cache.A * (ΔW_clip / denom)
+end
+
+"""
+    heavy_leading_1overW_coeff(cache::HeavyInelasticCache, l::Int64)
+
+Computes the coefficient of the leading `1 / W` angular correction for Legendre order `l`.
+
+# Input Argument(s)
+- `cache::HeavyInelasticCache` : reusable constants for this subshell and particle.
+- `l::Int64` : Legendre order.
+
+# Output Argument(s)
+- `coef::Float64` : coefficient such that the leading correction is `coef / W`.
+"""
+function heavy_leading_1overW_coeff(cache::HeavyInelasticCache, l::Int64)
+    if l == 0
+        return 0.0
+    end
+    # P_l'(1) = l*(l+1)/2
+    Plp1 = l * (l + 1) / 2.0
+    # coef for 1/W term: -A * P_l'(1) * mu_lin
+    coef = -cache.A * Plp1 * cache.mu_lin
+    return coef
+end
+
+"""
+    integrate_leading_1overW_per_subshell(cache::HeavyInelasticCache,
+    Ef_minus::Float64, Ef_plus::Float64, l::Int64)
+
+Integrates the leading `1 / W` angular correction analytically over an outgoing-energy
+group for one subshell and one Legendre order.
+
+# Input Argument(s)
+- `cache::HeavyInelasticCache` : reusable constants for this subshell and particle.
+- `Ef_minus::Float64` : upper bound of the outgoing particle energy group [in m_e*c^2].
+- `Ef_plus::Float64` : lower bound of the outgoing particle energy group [in m_e*c^2].
+- `l::Int64` : Legendre order.
+
+# Output Argument(s)
+- `σl::Float64` : integral of the leading angular correction over the clipped group.
+"""
+function integrate_leading_1overW_per_subshell(cache::HeavyInelasticCache, Ef_minus::Float64, Ef_plus::Float64, l::Int64)
+    if l == 0
+        return 0.0
+    end
+
+    W_plus = cache.Ei - Ef_plus
+    W_minus = cache.Ei - Ef_minus
+    W_lo = max(W_minus, 1e-300)
+    W_hi = min(W_plus, cache.W_ridge)
+    if W_hi <= W_lo
+        return 0.0
+    end
+
+    coef = heavy_leading_1overW_coeff(cache, l)
+    ΔW = W_hi - W_lo
+    # stable log: log(W_hi/W_lo) = log1p(ΔW/W_lo) when ΔW small
+    if ΔW / W_lo < 1e-6
+        log_ratio = log1p(ΔW / W_lo)
+    else
+        log_ratio = log(W_hi) - log(W_lo)
+    end
+    return coef * log_ratio
+end
+
+"""
+    angular_inelastic_collision_heavy_particle(Ei::Float64, Ef::Float64, L::Int64,
+    particle::Particle)
+
+Computes Legendre polynomial values for the inelastic angular deflection of a heavy
+particle after an energy loss.
+
+# Input Argument(s)
+- `Ei::Float64` : incoming particle energy [in m_e*c^2].
+- `Ef::Float64` : outgoing particle energy [in m_e*c^2].
+- `L::Int64` : maximum Legendre order.
+- `particle::Particle` : incoming heavy charged particle.
+
+# Output Argument(s)
+- `Pl::Vector{Float64}` : Legendre polynomial values from order 0 to `L`.
+"""
+function angular_inelastic_collision_heavy_particle(Ei::Float64, Ef::Float64, L::Int64, particle::Particle)
+    mₑ = 0.51099895069
+    M  = get_mass(particle) / mₑ  # ratio_mass
+
+    W = Ei - Ef
+    if W <= 0.0 || Ef <= 0.0 || Ei <= 0.0
+        return legendre_polynomials_up_to_L(L, 1.0)  # forward
+    end
+
+    pi2 = Ei*(Ei + 2.0*M)
+    pf2 = Ef*(Ef + 2.0*M)
+    pe2 = W*(W + 2.0)
+
+    denom = 2.0*sqrt(pi2*pf2)
+    if denom <= 0.0
+        μ = 1.0
+    else
+        μ = (pi2 + pf2 - pe2)/denom
+        μ = clamp(μ, -1.0, 1.0)
+    end
+
+    return legendre_polynomials_up_to_L(L, μ)
+end
+
+"""
+    integrate_inelastic_collision_heavy_particle(Z::Int64, Ei::Float64, n::Int64,
+    particle::Particle, E⁻min::Float64=0.0)
+
+Computes the subshell-summed analytical energy-loss moment of the heavy-particle
+inelastic collision cross-section for one element.
+
+# Input Argument(s)
+- `Z::Int64` : atomic number.
+- `Ei::Float64` : incoming particle energy [in m_e*c^2].
+- `n::Int64` : energy-loss moment order, either 0 or 1.
+- `particle::Particle` : incoming heavy charged particle.
+- `E⁻min::Float64=0.0` : lower cutoff for the transferred energy [in m_e*c^2].
+
+# Output Argument(s)
+- `σn::Float64` : analytical moment summed over all subshells.
+"""
 function integrate_inelastic_collision_heavy_particle(Z::Int64,Ei::Float64,n::Int64,particle::Particle,E⁻min::Float64=0.0)
     Nshells,Zi,Ui,_,_,_ = electron_subshells(Z)
     σn = 0
@@ -48,10 +304,27 @@ function integrate_inelastic_collision_heavy_particle(Z::Int64,Ei::Float64,n::In
         σn += Zi[δi] * integrate_inelastic_collision_heavy_particle_per_subshell(Ei,n,Ui[δi],particle,E⁻min)
     end
     return σn
-  end
+end
 
+"""
+    integrate_inelastic_collision_heavy_particle_per_subshell(Ei::Float64, n::Int64,
+    Ui::Float64, particle::Particle, E⁻min::Float64=0.0)
+
+Computes the analytical energy-loss moment of the heavy-particle inelastic collision
+cross-section for one subshell.
+
+# Input Argument(s)
+- `Ei::Float64` : incoming particle energy [in m_e*c^2].
+- `n::Int64` : energy-loss moment order, either 0 or 1.
+- `Ui::Float64` : subshell binding energy [in m_e*c^2].
+- `particle::Particle` : incoming heavy charged particle.
+- `E⁻min::Float64=0.0` : lower cutoff for the transferred energy [in m_e*c^2].
+
+# Output Argument(s)
+- `σni::Float64` : analytical moment for the subshell.
+"""
 function integrate_inelastic_collision_heavy_particle_per_subshell(Ei::Float64,n::Int64,Ui::Float64,particle::Particle,E⁻min::Float64=0.0)
-    
+
     #----
     # Initialization
     #----
@@ -63,24 +336,122 @@ function integrate_inelastic_collision_heavy_particle_per_subshell(Ei::Float64,n
     β² = (γ^2-1)/γ^2
     R = 1/(1+(1/ratio_mass)^2+2*γ/ratio_mass)
     W_ridge = 2*β²*γ^2*R
-    
+
     #----
     # Cross-section
     #----
     σni = 0
     W⁺ = min(Ei,W_ridge)
-    W⁻ = E⁻min+Ui
+    W⁻ = max(E⁻min,Ui)
     if W⁺ > W⁻
+        ΔW = W⁺ - W⁻
         if n == 0
-            J₀(W) = -1/W + β²/W_ridge*log(W) + (1-β²)/(2*ratio_mass^2)*W
-            σni = J₀(W⁺) - J₀(W⁻)
+            if ΔW / W⁺ < 1e-6
+                σni = ΔW/W⁺^2 - (β²/W_ridge)*(ΔW/W⁺ - 0.5*(ΔW/W⁺)^2) + ((1-β²)/(2*ratio_mass^2))*ΔW
+            else
+                σni = ΔW / (W⁺ * W⁻) - (β² / W_ridge) * log1p(ΔW / W⁻) + ((1 - β²)/(2*ratio_mass^2)) * ΔW
+            end
         elseif n == 1
-            J₁(W) = log(W) + β²/W_ridge*W + (1-β²)/(2*ratio_mass^2)*W^2/2
-            σni = J₁(W⁺) - J₁(W⁻)
+            if ΔW / W⁻ < 1e-6
+                log_term = ΔW / W⁻ - 0.5*(ΔW/W⁻)^2
+            else
+                log_term = log1p(ΔW / W⁻)
+            end
+            σni = log_term - (β² / W_ridge) * ΔW + ((1 - β²)/(4 * ratio_mass^2)) * ΔW * (W⁺ + W⁻)
         else
             error("Integral is given only for n=0 or n=1.")
         end
     end
     σni *= 2*π*rₑ^2/β² * Zc^2
     return σni
+end
+
+"""
+    feed_analytical_heavy_particle(cache::HeavyInelasticCache, Ef⁻::Float64,
+    Ef⁺::Float64)
+
+Computes the scalar analytical feed integral for heavy-particle inelastic collisions over
+an outgoing-energy group.
+
+# Input Argument(s)
+- `cache::HeavyInelasticCache` : reusable constants for this subshell and particle.
+- `Ef⁻::Float64` : upper bound of the outgoing particle energy group [in m_e*c^2].
+- `Ef⁺::Float64` : lower bound of the outgoing particle energy group [in m_e*c^2].
+
+# Output Argument(s)
+- `σs::Float64` : scalar feed integral over the group.
+
+"""
+function feed_analytical_heavy_particle(cache::HeavyInelasticCache, Ef⁻::Float64, Ef⁺::Float64)
+    # Compute the scalar analytical integral of σ over the group (l=0 moment)
+    σs = 0.0
+    ΔEf = Ef⁻ - Ef⁺
+
+    # Only integrate if energy transfer is within physical limits
+    if cache.W_ridge <= 0 || ΔEf <= 0
+        return σs
+    end
+
+    # Energy bounds for integration (W = Ei - Ef)
+    W⁺ = cache.Ei - Ef⁺
+    W⁻ = cache.Ei - Ef⁻
+
+    if W⁺ <= W⁻
+        return σs
+    end
+
+    #----
+    # Analytical integration over the energy group for the l=0 moment
+    #----
+    ΔW = W⁺ - W⁻
+
+    if ΔW / W⁺ < 1e-6
+        σs = ΔW/W⁺^2 - (cache.β²/cache.W_ridge)*(ΔW/W⁺ - 0.5*(ΔW/W⁺)^2) + ((1-cache.β²)/(2*cache.ratio_mass^2))*ΔW
+    else
+        σs = ΔW / (W⁺ * W⁻) - (cache.β² / cache.W_ridge) * log1p(ΔW / W⁻) + ((1 - cache.β²)/(2*cache.ratio_mass^2)) * ΔW
+    end
+    σs *= cache.A
+
+    return σs
+end
+
+"""
+    feed_first_moment_heavy_particle(cache::HeavyInelasticCache, Ef⁻::Float64,
+    Ef⁺::Float64)
+
+Computes the first energy-loss moment of the heavy-particle inelastic feed integral over
+an outgoing-energy group.
+
+# Input Argument(s)
+- `cache::HeavyInelasticCache` : reusable constants for this subshell and particle.
+- `Ef⁻::Float64` : upper bound of the outgoing particle energy group [in m_e*c^2].
+- `Ef⁺::Float64` : lower bound of the outgoing particle energy group [in m_e*c^2].
+
+# Output Argument(s)
+- `M₁::Float64` : first energy-loss moment over the group.
+
+"""
+function feed_first_moment_heavy_particle(cache::HeavyInelasticCache, Ef⁻::Float64, Ef⁺::Float64)
+    # Energy bounds for integration (W = Ei - Ef)
+    W⁺ = cache.Ei - Ef⁺
+    W⁻ = cache.Ei - Ef⁻
+
+    if W⁺ <= W⁻
+        return 0.0
+    end
+
+    #----
+    # First moment (n=1): ∫ W * σ(W) dW
+    #----
+    ΔW = W⁺ - W⁻
+
+    if ΔW / W⁻ < 1e-6
+        log_term = ΔW / W⁻ - 0.5*(ΔW/W⁻)^2
+    else
+        log_term = log1p(ΔW / W⁻)
+    end
+    M₁ = log_term - (cache.β² / cache.W_ridge) * ΔW + ((1 - cache.β²)/(4 * cache.ratio_mass^2)) * ΔW * (W⁺ + W⁻)
+    M₁ *= cache.A
+
+    return M₁
 end

--- a/src/structures/Inelastic_Collision.jl
+++ b/src/structures/Inelastic_Collision.jl
@@ -341,12 +341,19 @@ function dcs(this::Inelastic_Collision,Z::Int64,L::Int64,Ei::Float64,Ef::Float64
     #----
     # Close collisions
     #----
+    is_heavy = false
+    sigma_reg = 0.0
+    A_over_W2 = 0.0
+    cache = nothing
     if is_electron(particle)
         σs += moller(Zi,Ei,W,Ui,Ti,this.is_focusing_møller,this.is_hydrogenic_distribution_term)
     elseif is_positron(particle)
         σs += bhabha(Zi,Ei,W)
     elseif is_proton(particle) || is_alpha(particle)
-        σs += inelastic_collision_heavy_particle(Zi,Ei,W,particle)
+        is_heavy = true
+        # Create cache once for all Legendre orders
+        cache = HeavyInelasticCache(Zi, Ei, particle)
+        sigma_reg, A_over_W2 = heavy_sigma_components(cache, W)
     else
         error("Unknown particle")
     end
@@ -354,12 +361,29 @@ function dcs(this::Inelastic_Collision,Z::Int64,L::Int64,Ei::Float64,Ef::Float64
     #----
     # Compute the angular distribution
     #----
-    Wl = angular_moller(Ei,Ef,L)
+    if is_heavy
+        Wl = angular_inelastic_collision_heavy_particle(Ei,Ef,L,particle)
+    else
+        Wl = angular_moller(Ei,Ef,L)
+    end
 
     #----
     # Compute the Legendre moments of the cross-section
     #----
-    for l in range(0,L) σl[l+1] += Wl[l+1] * σs end
+    if is_heavy
+        for l in range(0,L)
+            # Subtract analytic leading 1/W piece to regularize the numeric integrand
+            if W > 0
+                coef = heavy_leading_1overW_coeff(cache, l)
+                leading_term = coef / W
+            else
+                leading_term = 0.0
+            end
+            σl[l+1] += Wl[l+1] * sigma_reg + (Wl[l+1] - 1.0) * A_over_W2 - leading_term
+        end
+    else
+        for l in range(0,L) σl[l+1] += Wl[l+1] * σs end
+    end
     return σl
 end
 


### PR DESCRIPTION
Introduces HeavyInelasticCache to precompute per-subshell kinematic constants once, then adds an analytic treatment of the singular 1/W^2 forward-scattering peak that previously caused quadrature undersampling for protons and alpha particles.

Key changes:
- inelastic_collision_heavy_particle.jl: new HeavyInelasticCache struct; analytic singular treatment; correct relativistic scattering angle via angular_inelastic_collision_heavy_particle; analytic group feed functions; numerically stable log1p forms; lower bound corrected to max(E_min,Ui).
- Inelastic_Collision.jl (dcs): split DCS into regular + singular with per-order regularization; use angular_inelastic_collision_heavy_particle.
- feed.jl: analytic singular contribution for heavy inelastic scattering on top of quadrature; runtime consistency check with @warn.