### PR TITLE
Fix resonance energy calculation for hydrogen (Z=1)

### DIFF
--- a/src/cross_sections/resonance_energy.jl
+++ b/src/cross_sections/resonance_energy.jl
@@ -22,6 +22,13 @@ Nshells,Zi,Ui,_,_,_ = electron_subshells(Z)
 # Find parameter a
 f(a) = sum(Zi.*log.(sqrt.((a.*Ui).^2 + 2/3*Zi./Z.*Ωp^2))) - Z*log(I)
 dfda(a) = sum(Zi.*Ui.^2 .*a./(Ui.^2 .*a.^2 .+ 2/3 .* Zi./Z.*Ωp^2))
+
+if Z == 1
+    Wi = zeros(1)
+    Wi[1] = I
+    return Wi
+end
+
 a = newton_bisection(f,dfda,0,100,1e-4,2000)
 
 # Compute the resonance energies


### PR DESCRIPTION
The general solver breaks for hydrogen because it has only one subshell and the resonance energy equation degenerates. Return the mean excitation energy I directly instead of running the Newton-bisection solver.