### PR TITLE
Fix MATXS support and density handling

### DIFF
--- a/docs/src/user_guide_matxs_format.md
+++ b/docs/src/user_guide_matxs_format.md
@@ -11,12 +11,15 @@ record structure, the reaction-name keywords and the particle codes used by Radi
 the files can be inspected or exchanged with other tools.
 
 !!! note "Interoperability and round-trip"
-    Radiant writes two layers of reactions. A *standard* interop layer uses recognized MATXS
-    reaction names (`*tot0`, `*heat`, `*scat`) so that NJOY/TRANSX-style tooling can read the
-    main quantities. An *extension* layer (`*edep`, `*abs`, `*momt`, `*stpw`, `*cdep`) carries
-    the Radiant-specific quantities that have no standard MATXS slot; tools that do not
-    recognize these names simply skip them. Reading a Radiant-written MATXS file back therefore
-    reproduces the original `Cross_Sections` exactly.
+    Radiant writes a standard subset (`*tot0`, `*heat`, `*char`, `*scat`) plus
+    Radiant-specific vectors required for lossless reconstruction (`*abs`, `*edep`, and the
+    charged-particle `EMOMTR`/`BSTC`/`PSTC` vectors). NJOY/TRANSX-style tooling may consume
+    the standard subset, while `read_matxs` requires the full Radiant vector set. Standard-only
+    MATXS input is rejected because the missing vectors cannot be reconstructed reliably.
+
+    Radiant stores cross-section quantities internally as macroscopic values. When writing
+    MATXS, vector and matrix values are divided by the supplied material density; when reading,
+    they are multiplied by that density again.
 
 ## File structure
 
@@ -82,24 +85,25 @@ Each reaction name is the incident-particle code followed by a reaction suffix. 
 reactions (record ` 6d `/` 7d `) are written only on the self pairs; the matrix reaction
 (record ` 8d `/` 9d `) is written for every pair. Using the photon prefix `g` as an example:
 
-| Keyword   | Layer     | Length  | Radiant quantity                                       |
-|-----------|-----------|---------|--------------------------------------------------------|
-| `gtot0`   | standard  | `Ng`    | `get_total` — total cross-section (P₀).                |
-| `gheat`   | standard  | `Ng`    | Heating / energy deposition (the per-group part of `get_energy_deposition`). |
-| `gscat`   | standard  | banded  | `get_scattering` — group-to-group transfer matrix, Legendre orders `0…L`. |
-| `gedep`   | extension | `Ng+1`  | `get_energy_deposition` (authoritative; supersedes `gheat` on read). |
-| `gabs`    | extension | `Ng`    | `get_absorption`.                                      |
-| `gmomt`   | extension | `Ng`    | `get_momentum_transfer`.                               |
-| `gstpw`   | extension | `Ng+1`  | `get_boundary_stopping_powers`.                        |
-| `gcdep`   | extension | `Ng+1`  | `get_charge_deposition`.                               |
+| Particle | Vector names |
+|----------|--------------|
+| photon | `gtot0`, `gheat`, `gchar`, `gabs`, `gedep` |
+| electron | `btot0`, `bheat`, `bchar`, `babs`, `EMOMTR`, `BSTC`, `bedep` |
+| positron | `ptot0`, `pheat`, `pchar`, `pabs`, `PSTC`, `pedep` |
 
-The same suffixes apply with the `b` (electron) and `p` (positron) prefixes. On reading,
-`*heat` is ignored because the full `Ng+1` energy-deposition vector is recovered from `*edep`.
+For every incident particle, `*tot0` has length `Ng`, `*abs` has length `Ng`, and `*edep`
+has length `Ng+1`. Charge deposition is represented by either `*cdep` with length `Ng+1`
+or `*char` with length `Ng`; the latter receives a zero appended at the lower boundary.
+`*momt` and `*stpw` are optional and default to zero vectors when absent. The legacy private
+names `*momt`, `*stpw`, and `*cdep` remain accepted on input but are not emitted.
+
+On reading, `*heat` is ignored as an authoritative value because the full `Ng+1` energy-
+deposition vector is recovered from `*edep`.
 
 ### Scattering-matrix banding
 
 The transfer matrix is stored in the compact banded form used by MATXS. For each outgoing
-group, `jband` gives the number of contributing incident groups and `ijj` the lowest incident
+group, `jband` gives the number of contributing incident groups and `ijj` the highest incident
 group number of the band. Within a band the data are ordered by Legendre moment (`P₀` band,
 then `P₁` band, …), and the incident groups within each moment are listed in descending order.
 
@@ -111,6 +115,8 @@ auto-detects the encoding from the first bytes of the file.
 - **BCD / ASCII** (`binary = false`, default) — tagged text records. Reals are written as
   fixed-width `e12.5` fields (6 per line), integers as `i6` (12 per line) and hollerith
   identifiers as `a8` (8 per line).
+- **Energy units** — Radiant group boundaries are stored internally in MeV; MATXS group
+  boundaries are written and read in eV, with a factor of `10⁶` applied at the format boundary.
 - **Binary** (`binary = true`) — each record is written as a single FORTRAN-style unformatted
   record: a 4-byte `Int32` length marker, a payload of native-endian `Int32` integers,
   `Float64` reals and 8-byte hollerith fields, and a trailing length marker.
@@ -119,8 +125,8 @@ auto-detects the encoding from the first bytes of the file.
     - The binary encoding is a **Radiant variant** (`Int32`/`Float64` payloads); it is not
       guaranteed byte-compatible with NJOY's own binary MATXS files. Validate against a
       reference file if true binary interoperability with NJOY is required.
-    - The exact standard reaction-name strings and the positron code are provisional. Confirm
-      them against the specific TRANSX/MATXS naming of your toolchain when exchanging files.
+    - Reaction-name conventions and the positron code should be validated against the specific
+      TRANSX/MATXS naming expected by your toolchain when exchanging files.
 
 ## Example
 

--- a/src/cross_sections/read_matxs.jl
+++ b/src/cross_sections/read_matxs.jl
@@ -3,8 +3,15 @@
 
 Read a MATXS-format (NJOY/CCCC) cross-sections file and store its content in a Cross_Sections
 structure. This is the counterpart of [`write_matxs`](@ref) and reverses both the standard
-interop reactions (`*tot0`, `*heat`, `*scat`) and the Radiant-private extension reactions
-(`*edep`, `*abs`, `*momt`, `*stpw`, `*cdep`) to rebuild the full multigroup data set.
+interop reactions (`*tot0`, `*heat`, `*char`, `*scat`) and the Dragon-facing charged-particle
+reactions (`EMOMTR`, `BSTC`, `PSTC`). Older Radiant-private extension reactions
+(`*momt`, `*stpw`, `*cdep`) are still accepted when present.
+
+Radiant requires the `*tot0`, `*abs`, `*edep`, and either `*cdep` or `*char` vector for
+each incident particle in order to reconstruct a complete cross-section library. The
+`*momt` and `*stpw` vectors are optional and default to zero when absent. Standard-only
+MATXS files that omit Radiant's required extension vectors are therefore rejected with an
+explicit error rather than being reconstructed with guessed values.
 
 The BCD (ASCII) and binary encodings produced by `write_matxs` are both supported; the
 encoding is auto-detected from the first bytes of the file.
@@ -42,6 +49,10 @@ ctrl = _matxs_ints!(rd,6)
 Npart,ntype,nholl,Nmat = ctrl[1],ctrl[2],ctrl[3],ctrl[4]
 if Npart != Npart_cs error("MATXS file holds $Npart particles but $Npart_cs were provided.") end
 if Nmat  != cross_sections.get_number_of_materials() error("MATXS file material count mismatch.") end
+densities = cross_sections.get_densities()
+if any(densities .<= 0.0)
+    error("MATXS input requires strictly positive material densities.")
+end
 
 #----
 # Record 2 : set hollerith identification (ignored)
@@ -77,7 +88,7 @@ Ng = zeros(Int64,Npart)                          # indexed by provided-particle 
 energy_boundaries = Vector{Vector{Float64}}(undef,Npart)
 for j in range(1,Npart)
     _matxs_next!(rd," 4d ")
-    eb = _matxs_reals!(rd,ngrp_f[j]+1)
+    eb = _matxs_reals!(rd,ngrp_f[j]+1) ./ 1.0e6
     n = slot2cs[j]
     Ng[n] = ngrp_f[j]
     energy_boundaries[n] = eb
@@ -121,7 +132,7 @@ for mfile in range(1,Nmat)
             d = get!(vecs,i,Dict{String,Vector{Float64}}())
             pos = 0
             for k in range(1,sub_n1d[s])
-                sfx = strip(hvps[k])[2:end]       # drop the particle-code prefix
+                sfx = matxs_vector_key(strip(hvps[k]))
                 d[sfx] = vps[pos+1:pos+lengths[k]]
                 pos += lengths[k]
             end
@@ -144,7 +155,7 @@ for mfile in range(1,Nmat)
             for gf in range(1,Ngo)
                 jb = jband[gf]; ij = ijj[gf]
                 if jb == 0 continue end
-                for l in range(1,lord), gi in (ij+jb-1):-1:ij
+                for l in range(1,lord), gi in ij:-1:(ij-jb+1)
                     pos += 1
                     scat[gi,gf,l] = mdat[pos]
                 end
@@ -156,15 +167,30 @@ for mfile in range(1,Nmat)
     # Assemble Multigroup_Cross_Sections for each incident particle of this material
     for n in range(1,Npart)
         mcs = Multigroup_Cross_Sections(Ng[n])
-        d = vecs[n]
-        mcs.set_total(d["tot0"])
-        mcs.set_absorption(d["abs"])
-        mcs.set_momentum_transfer(d["momt"])
-        mcs.set_energy_deposition(d["edep"])      # authoritative Ng+1 (heat is interop-only)
-        mcs.set_boundary_stopping_powers(d["stpw"])
-        mcs.set_charge_deposition(d["cdep"])
+        d = get(vecs,n,Dict{String,Vector{Float64}}())
+        rho = densities[mfile]
+        code = matxs_particle_code(particles[n])
+        total = _matxs_required_vector(d,"tot0",Ng[n],code)
+        absorption = _matxs_required_vector(d,"abs",Ng[n],code)
+        energy_deposition = _matxs_required_vector(d,"edep",Ng[n]+1,code)
+        momentum_transfer = _matxs_optional_vector(d,"momt",Ng[n],code)
+        stopping_powers = _matxs_optional_vector(d,"stpw",Ng[n]+1,code)
+        if haskey(d,"cdep")
+            charge = _matxs_vector(d,"cdep",Ng[n]+1,code)
+        elseif haskey(d,"char")
+            charge = vcat(_matxs_vector(d,"char",Ng[n],code),0.0)
+        else
+            error("MATXS file is missing required charge-deposition vector 'cdep' or 'char' for incident particle '$code'.")
+        end
+        mcs.set_total(total .* rho)
+        mcs.set_absorption(absorption .* rho)
+        mcs.set_momentum_transfer(momentum_transfer .* rho)
+        mcs.set_energy_deposition(energy_deposition .* rho) # authoritative Ng+1 (heat is interop-only)
+        mcs.set_boundary_stopping_powers(stopping_powers .* rho)
+        charge = charge .* rho
+        mcs.set_charge_deposition(charge)
         for nout in range(1,Npart)                # push scattering in outgoing order
-            mcs.set_scattering(mats[(n,nout)])
+            mcs.set_scattering(mats[(n,nout)] .* rho)
         end
         multigroup_cross_sections[n,mfile] = mcs
     end
@@ -185,6 +211,31 @@ cross_sections.set_multigroup_cross_sections(multigroup_cross_sections)
 
 end
 
+function _matxs_required_vector(data::Dict{String,Vector{Float64}},name::String,
+                                length_expected::Int64,code::String)
+    if !haskey(data,name)
+        error("MATXS file is missing required vector '*$name' for incident particle '$code'.")
+    end
+    return _matxs_vector(data,name,length_expected,code)
+end
+
+function _matxs_optional_vector(data::Dict{String,Vector{Float64}},name::String,
+                                length_expected::Int64,code::String)
+    if !haskey(data,name)
+        return zeros(length_expected)
+    end
+    return _matxs_vector(data,name,length_expected,code)
+end
+
+function _matxs_vector(data::Dict{String,Vector{Float64}},name::String,
+                       length_expected::Int64,code::String)
+    vector = data[name]
+    if length(vector) != length_expected
+        error("MATXS vector '*$name' for incident particle '$code' has length $(length(vector)); expected $length_expected.")
+    end
+    return vector
+end
+
 #----
 # Unified MATXS record reader (BCD/ASCII or binary)
 #----
@@ -193,6 +244,8 @@ mutable struct _Matxs_Reader
     binary ::Bool
     lines  ::Vector{String}   # BCD : record lines (columns preserved)
     li     ::Int64
+    rec    ::Vector{String}   # BCD : current record payload lines
+    ri     ::Int64
     io     ::IO               # binary : record stream
     buf    ::Vector{UInt8}    # binary : current record payload
     pos    ::Int64
@@ -212,9 +265,9 @@ function _Matxs_Reader(is_bcd::Bool,raw::Vector{UInt8})
         for line in split(String(raw),'\n')
             push!(lines,endswith(line,"\r") ? String(line[1:end-1]) : String(line))
         end
-        return _Matxs_Reader(false,lines,1,IOBuffer(),UInt8[],1)
+        return _Matxs_Reader(false,lines,1,String[],1,IOBuffer(),UInt8[],1)
     else
-        return _Matxs_Reader(true,String[],1,IOBuffer(raw),UInt8[],1)
+        return _Matxs_Reader(true,String[],1,String[],1,IOBuffer(raw),UInt8[],1)
     end
 end
 
@@ -232,8 +285,60 @@ function _matxs_next!(rd::_Matxs_Reader,tag::String)
         read(rd.io,Int32)                          # trailing length marker
         rd.pos = 1
     else
-        if strip(rd.lines[rd.li]) != strip(tag) error("Expected MATXS record '$tag' at line $(rd.li): $(rd.lines[rd.li])") end
+        if rd.li > length(rd.lines) error("Expected MATXS record '$tag' at end of file.") end
+        if !_matxs_is_tag_line(rd.lines[rd.li],tag)
+            error("Expected MATXS record '$tag' at line $(rd.li): $(rd.lines[rd.li])")
+        end
+        first_line = rd.lines[rd.li]
         rd.li += 1
+        payload = String[]
+        while rd.li <= length(rd.lines) && !_matxs_starts_record(rd.lines[rd.li])
+            push!(payload,rd.lines[rd.li])
+            rd.li += 1
+        end
+        rd.rec = _matxs_bcd_payload(tag,first_line,payload)
+        rd.ri = 1
+    end
+end
+
+function _matxs_is_tag_line(line::String,tag::String)
+    return length(line) >= 4 && strip(line[1:4]) == strip(tag)
+end
+
+function _matxs_starts_record(line::String)
+    tags = ("0v","1d","2d","3d","4d","5d","6d","7d","8d","9d","10d")
+    return length(line) >= 4 && strip(line[1:4]) in tags
+end
+
+function _matxs_bcd_payload(tag::String,first_line::String,continuation::Vector{String})
+    line = rpad(first_line,4)
+    rest = line[5:end]
+    if strip(rest) == ""
+        return continuation
+    end
+    if tag == " 0v "
+        rest = rpad(rest,35)
+        return String[rest[1:8] * rest[10:17], rest[end-5:end]]
+    elseif tag == " 1d "
+        return vcat(String[rest[3:end]],continuation)
+    elseif tag == " 2d " || tag == " 3d " || tag == " 6d "
+        return vcat(String[rest[5:end]],continuation)
+    elseif tag == " 4d " || tag == " 7d " || tag == " 9d " || tag == "10d "
+        return vcat(String[rest[9:end]],continuation)
+    elseif tag == " 5d "
+        rest = rpad(rest,20)
+        real_lines = String[rest[9:end]]
+        int_lines = String[]
+        for cont in continuation
+            cont = rpad(cont,48)
+            push!(real_lines,cont[1:24])
+            push!(int_lines,cont[25:48])
+        end
+        return vcat(String[rest[1:8]],real_lines,int_lines)
+    elseif tag == " 8d "
+        return vcat(String[rpad(rest,12)[5:12]],continuation)
+    else
+        error("Unsupported MATXS BCD record tag '$tag'.")
     end
 end
 
@@ -252,8 +357,8 @@ function _matxs_reals!(rd::_Matxs_Reader,n::Int64)
     else
         got = 0
         while got < n
-            line = rd.lines[rd.li]; rd.li += 1
-            k = min(6,n-got)
+            line = rd.rec[rd.ri]; rd.ri += 1
+            k = min(length(line) ÷ 12,n-got)
             for j in 1:k
                 got += 1
                 out[got] = parse(Float64,strip(line[(j-1)*12+1:j*12]))
@@ -278,8 +383,8 @@ function _matxs_ints!(rd::_Matxs_Reader,n::Int64)
     else
         got = 0
         while got < n
-            line = rd.lines[rd.li]; rd.li += 1
-            k = min(12,n-got)
+            line = rd.rec[rd.ri]; rd.ri += 1
+            k = min(length(line) ÷ 6,n-got)
             for j in 1:k
                 got += 1
                 out[got] = parse(Int,strip(line[(j-1)*6+1:j*6]))
@@ -305,8 +410,9 @@ function _matxs_holl!(rd::_Matxs_Reader,n::Int64)
     else
         got = 0
         while got < n
-            k = min(8,n-got)
-            line = rpad(rd.lines[rd.li],k*8); rd.li += 1   # tolerate trailing-space trimming
+            line = rd.rec[rd.ri]; rd.ri += 1
+            k = min(max(length(line) ÷ 8,1),n-got)
+            line = rpad(line,k*8)   # tolerate trailing-space trimming
             for j in 1:k
                 got += 1
                 out[got] = line[(j-1)*8+1:j*8]
@@ -314,4 +420,16 @@ function _matxs_holl!(rd::_Matxs_Reader,n::Int64)
         end
     end
     return out
+end
+
+function matxs_vector_key(name::AbstractString)
+    if name == "EMOMTR"
+        return "momt"
+    elseif name in ("BSTC","CSTC","PSTC")
+        return "stpw"
+    elseif length(name) >= 2
+        sfx = name[2:end]
+        return sfx == "char" ? "char" : sfx
+    end
+    return name
 end

--- a/src/cross_sections/write_matxs.jl
+++ b/src/cross_sections/write_matxs.jl
@@ -6,15 +6,22 @@ Write a MATXS-format (NJOY/CCCC) cross-sections file from a Cross_Sections struc
 The file follows the CCCC MATXS record structure produced by NJOY's `matxsr` module
 (file identification → file control → set hollerith id → file data → group structures →
 material control → vector control/blocks → matrix control/sub-blocks). To round-trip the
-full Radiant data set without loss, two layers of reactions are written:
+full Radiant data set without loss, standard and Radiant-specific reactions are written:
 
-- a *standard* interop layer using recognized MATXS reaction names so that NJOY/TRANSX-style
-  tooling can read the leading total (`*tot0`) and heating (`*heat`) vectors and the banded
-  group-to-group transfer matrices (`*scat`);
-- an *extension* layer of Radiant-private vector reactions (`*edep`, `*abs`, `*momt`,
-  `*stpw`, `*cdep`) carrying the quantities that have no standard MATXS slot. Tools that do
-  not recognize these names simply skip them; `read_matxs` keys on them to rebuild the exact
-  Cross_Sections.
+- standard vectors use the recognized total (`*tot0`), heating (`*heat`), charge (`*char`),
+  and scattering (`*scat`) names;
+- Radiant-specific vectors use `*abs` and `*edep`, plus `EMOMTR`/`BSTC`/`PSTC` for charged
+  particles. These vectors carry the data required to reconstruct the exact
+  `Cross_Sections`; tools that do not recognize them may consume only the standard subset.
+
+The emitted vector names are `gtot0`, `gheat`, `gchar`, `gabs`, `gedep` for photons;
+`btot0`, `bheat`, `bchar`, `babs`, `EMOMTR`, `BSTC`, `bedep` for electrons; and
+`ptot0`, `pheat`, `pchar`, `pabs`, `PSTC`, `pedep` for positrons. Legacy Radiant-private
+names are accepted by `read_matxs` but are not emitted.
+
+Radiant stores energy boundaries internally in MeV and writes them in MATXS eV. Vector and
+matrix values are divided by material density when written; `read_matxs` multiplies them by
+the supplied material density when rebuilding the library.
 
 Two encodings are supported and share the same record content: the BCD (ASCII) encoding
 (`binary=false`, tagged text records with `e12.5`/`i6`/`a8` fields) and a binary encoding
@@ -45,19 +52,28 @@ Npart = cross_sections.get_number_of_particles()
 Nmat = cross_sections.get_number_of_materials()
 L = cross_sections.get_legendre_order()
 lord = L + 1
+densities = [materials[m].density for m in range(1,Nmat)]
+if any(ismissing.(densities)) || any(densities .<= 0.0)
+    error("MATXS output requires strictly positive material densities.")
+end
+densities = Float64.(densities)
 
 Ng = [cross_sections.get_number_of_groups(particles[i]) for i in range(1,Npart)]
 codes = [matxs_particle_code(particles[i]) for i in range(1,Npart)]
 
-# Suffixes of the vector reactions written for each incident particle (fixed order, shared
-# by read_matxs).
-vector_suffixes = ["tot0","heat","edep","abs","momt","stpw","cdep"]
+# Vector reactions written for each incident particle (fixed order, shared by read_matxs).
+vector_names_by_particle = [matxs_vector_names(codes[i]) for i in range(1,Npart)]
 
 #----
 # File-level data type table : one type per ordered (incident,outgoing) particle pair.
 # Self pairs (jinp==joutp) additionally carry the vector reactions of the incident particle.
 #----
 ntype,htype,jinp,joutp = matxs_type_table(Npart,codes)
+n1d_by_type = [(jinp[t] == joutp[t]) ? length(vector_names_by_particle[jinp[t]]) : 0 for t in range(1,ntype)]
+n2d_by_type = ones(Int64,ntype)
+type_record_counts = [(n1d_by_type[t] > 0 ? 2 : 0) + 2*n2d_by_type[t] for t in range(1,ntype)]
+submaterial_locs = vcat([0],cumsum(type_record_counts)[1:end-1])
+material_record_count = 1 + sum(type_record_counts)
 
 #----
 # Write the MATXS file
@@ -82,13 +98,14 @@ try
     hprt  = [codes[i] for i in range(1,Npart)]
     hmatn = [string(first(materials[m].tag,8)) for m in range(1,Nmat)]
     nsubm = fill(ntype,Nmat)
-    locm  = zeros(Int64,Nmat)
+    locm  = [(m-1)*material_record_count for m in range(1,Nmat)]
     matxs_emit(io,binary," 3d ",[(:holl,vcat(hprt,htype,hmatn)),
                                  (:int,vcat(Ng,jinp,joutp,nsubm,locm))])
 
-    # Record 4 : group structures (per particle, descending bounds + emin)
+    # Record 4 : group structures (per particle, descending bounds + emin).
+    # MATXS stores energy boundaries in eV; Radiant keeps its internal energy grid in MeV.
     for i in range(1,Npart)
-        eb = cross_sections.get_energy_boundaries(particles[i])  # length Ng+1, descending
+        eb = 1.0e6 .* cross_sections.get_energy_boundaries(particles[i])
         matxs_emit(io,binary," 4d ",[(:real,collect(Float64,eb))])
     end
 
@@ -111,9 +128,10 @@ try
         reals5 = Float64[0.0]   # amass
         ints5  = Int64[]
         for t in range(1,ntype)
-            n1d = (jinp[t] == joutp[t]) ? length(vector_suffixes) : 0
+            n1d = n1d_by_type[t]
+            n2d = n2d_by_type[t]
             append!(reals5,[0.0,0.0])              # temp, sigz
-            append!(ints5,[t,n1d,1,0])             # itype, n1d, n2d, locs
+            append!(ints5,[t,n1d,n2d,submaterial_locs[t]]) # itype, n1d, n2d, locs
         end
         matxs_emit(io,binary," 5d ",[(:holl,[string(first(materials[m].tag,8))]),
                                      (:real,reals5),(:int,ints5)])
@@ -125,19 +143,31 @@ try
 
             # Vector control + block (self pairs only)
             if i == o
-                hvps = [codes[i]*sfx for sfx in vector_suffixes]
+                hvps = vector_names_by_particle[i]
                 nfg  = ones(Int64,length(hvps))
-                nlg  = [sfx in ("edep","stpw","cdep") ? Ngi+1 : Ngi for sfx in vector_suffixes]
+                nlg  = [name in ("BSTC","CSTC","PSTC") || endswith(name,"edep") ? Ngi+1 : Ngi for name in hvps]
                 matxs_emit(io,binary," 6d ",[(:holl,hvps),(:int,vcat(nfg,nlg))])
 
                 vps = Float64[]
-                append!(vps,total[i][:,m])           # tot0  (Ng)
-                append!(vps,edep[i][1:Ngi,m])         # heat  (Ng)   interop
-                append!(vps,edep[i][:,m])             # edep  (Ng+1) extension (authoritative)
-                append!(vps,absor[i][:,m])            # abs   (Ng)
-                append!(vps,momt[i][:,m])             # momt  (Ng)
-                append!(vps,stpw[i][:,m])             # stpw  (Ng+1)
-                append!(vps,cdep[i][:,m])             # cdep  (Ng+1)
+                for name in hvps
+                    if endswith(name,"tot0")
+                        append!(vps,total[i][:,m] ./ densities[m])
+                    elseif endswith(name,"heat")
+                        append!(vps,edep[i][1:Ngi,m] ./ densities[m])
+                    elseif endswith(name,"char")
+                        append!(vps,cdep[i][1:Ngi,m] ./ densities[m])
+                    elseif endswith(name,"abs")
+                        append!(vps,absor[i][:,m] ./ densities[m])
+                    elseif name == "EMOMTR"
+                        append!(vps,momt[i][:,m] ./ densities[m])
+                    elseif name in ("BSTC","CSTC","PSTC")
+                        append!(vps,stpw[i][:,m] ./ densities[m])
+                    elseif endswith(name,"edep")
+                        append!(vps,edep[i][:,m] ./ densities[m])
+                    else
+                        error("Unsupported MATXS vector name '$name'.")
+                    end
+                end
                 matxs_emit(io,binary," 7d ",[(:real,vps)])
             end
 
@@ -151,8 +181,8 @@ try
             for gf in range(1,Ngo)
                 jb = jband[gf]; ij = ijj[gf]
                 if jb == 0 continue end
-                for l in range(1,lord), gi in (ij+jb-1):-1:ij
-                    push!(mdat,matview[gi,gf,l])
+                for l in range(1,lord), gi in ij:-1:(ij-jb+1)
+                    push!(mdat,matview[gi,gf,l] / densities[m])
                 end
             end
             matxs_emit(io,binary," 9d ",[(:real,mdat)])
@@ -190,8 +220,8 @@ end
     matxs_band(matview,Ngi::Int64,Ngo::Int64)
 
 Compute the MATXS banding arrays `(jband,ijj)` of a `(Ngi,Ngo,L+1)` scattering matrix view :
-for each final group, `jband` is the number of contributing initial groups and `ijj` the
-lowest initial-group number in the band.
+for each final group, `jband` is the number of contributing initial groups and `ijj` is
+the highest initial-group number in the band.
 
 """
 function matxs_band(matview,Ngi::Int64,Ngo::Int64)
@@ -207,7 +237,7 @@ function matxs_band(matview,Ngi::Int64,Ngo::Int64)
         end
         if gmin != 0
             jband[gf] = gmax - gmin + 1
-            ijj[gf]   = gmin
+            ijj[gf]   = gmax
         end
     end
     return jband,ijj
@@ -228,6 +258,24 @@ function matxs_particle_code(particle::Particle)
 end
 
 """
+    matxs_vector_names(code::String)
+
+Return Dragon-facing MATXS vector names for an incident particle code. Records 35 and 36
+of FMAC-M are charged-particle quantities; keep them out of photon data.
+
+"""
+function matxs_vector_names(code::String)
+    if code == "b"
+        return ["btot0","bheat","bchar","babs","EMOMTR","BSTC","bedep"]
+    elseif code == "g"
+        return ["gtot0","gheat","gchar","gabs","gedep"]
+    elseif code == "p"
+        return ["ptot0","pheat","pchar","pabs","PSTC","pedep"]
+    end
+    error("Unsupported MATXS particle code '$code'.")
+end
+
+"""
     matxs_holl_words(str::String,nwords::Int64)
 
 Split a string into `nwords` fixed `a8` hollerith words (right-padded with spaces).
@@ -242,9 +290,9 @@ end
     matxs_emit(io::IO,binary::Bool,tag::String,segments)
 
 Write one MATXS record. `segments` is an ordered list of `(:int|:real|:holl, values)` pairs.
-In BCD mode the record is written as a tag line followed by fixed-width field lines (one
-segment per line group); in binary mode it is written as a single FORTRAN-style unformatted
-record (`Int32` length marker, payload of `Int32`/`Float64`/8-byte hollerith, length marker).
+In BCD mode the record tag and first payload fields are written on the same
+fixed-format line, following the CCCC/Dragon text reader conventions; in binary mode it
+is written as a single FORTRAN-style unformatted record (`Int32` length marker, payload of `Int32`/`Float64`/8-byte hollerith, length marker).
 
 """
 function matxs_emit(io::IO,binary::Bool,tag::String,segments)
@@ -265,16 +313,66 @@ function matxs_emit(io::IO,binary::Bool,tag::String,segments)
         marker = Int32(length(bytes))
         Base.write(io,marker); Base.write(io,bytes); Base.write(io,marker)
     else
-        println(io,tag)
-        for (kind,vals) in segments
-            if kind === :int
-                _matxs_write_ints(io,vals)
-            elseif kind === :real
-                _matxs_write_reals(io,vals)
-            elseif kind === :holl
-                _matxs_write_holl(io,vals)
-            end
+        _matxs_emit_bcd(io,tag,segments)
+    end
+end
+
+"""
+    _matxs_emit_bcd(io::IO,tag::String,segments)
+
+Write one BCD MATXS record using the fixed-column layout expected by the CCCC/Dragon
+reader.  The record tag occupies the first columns of the first payload line; continuation
+lines are untagged.
+
+"""
+function _matxs_emit_bcd(io::IO,tag::String,segments)
+    stag = rpad(tag,4)
+    if tag == " 0v "
+        holl = String.(segments[1][2])
+        ints = Int.(segments[2][2])
+        println(io,stag,rpad(first(holl[1],8),8)," ",rpad(first(holl[2],8),8),
+                rpad("",8)," ",@sprintf("%6d",ints[1]))
+    elseif tag == " 1d "
+        print(io,stag,"  ")
+        _matxs_write_ints(io,segments[1][2]; first_line=6, cont_line=12)
+    elseif tag == " 2d "
+        print(io,stag)
+        _matxs_write_holl(io,segments[1][2]; first_prefix="    ", first_line=8,
+                          cont_line=9)
+    elseif tag == " 3d "
+        print(io,stag)
+        _matxs_write_holl(io,segments[1][2]; first_prefix="    ", first_line=8,
+                          cont_line=9)
+        _matxs_write_ints(io,segments[2][2])
+    elseif tag == " 4d " || tag == " 7d " || tag == " 9d " || tag == "10d "
+        print(io,stag)
+        _matxs_write_reals(io,segments[1][2]; first_prefix="        ", first_line=5,
+                           cont_line=6)
+    elseif tag == " 5d "
+        holl = String.(segments[1][2])
+        reals = Float64.(segments[2][2])
+        ints = Int.(segments[3][2])
+        println(io,stag,rpad(first(holl[1],8),8),@sprintf("%12.5E",reals[1]))
+        nsub = length(ints) ÷ 4
+        for i in 1:nsub
+            rbase = 2 + 2*(i-1)
+            ibase = 1 + 4*(i-1)
+            println(io,@sprintf("%12.5E",reals[rbase]),@sprintf("%12.5E",reals[rbase+1]),
+                    @sprintf("%6d",ints[ibase]),@sprintf("%6d",ints[ibase+1]),
+                    @sprintf("%6d",ints[ibase+2]),@sprintf("%6d",ints[ibase+3]))
         end
+    elseif tag == " 6d "
+        print(io,stag)
+        _matxs_write_holl(io,segments[1][2]; first_prefix="    ", first_line=8,
+                          cont_line=9)
+        _matxs_write_ints(io,segments[2][2])
+    elseif tag == " 8d "
+        holl = String.(segments[1][2])
+        ints = Int.(segments[2][2])
+        println(io,stag,"    ",rpad(first(holl[1],8),8))
+        _matxs_write_ints(io,ints)
+    else
+        error("Unsupported MATXS BCD record tag '$tag'.")
     end
 end
 
@@ -284,10 +382,17 @@ end
 Write a sequence of reals as fixed-width `e12.5` fields, 6 per line.
 
 """
-function _matxs_write_reals(io::IO,vals)
+function _matxs_write_reals(io::IO,vals; first_prefix::String="", first_line::Int64=6,
+                            cont_line::Int64=6)
     fields = [@sprintf("%12.5E",Float64(v)) for v in vals]
-    for i in 1:6:length(fields)
-        println(io,join(fields[i:min(i+5,length(fields))]))
+    i = 1
+    nfirst = min(first_line,length(fields))
+    println(io,first_prefix*join(fields[i:i+nfirst-1]))
+    i += nfirst
+    while i <= length(fields)
+        n = min(cont_line,length(fields)-i+1)
+        println(io,join(fields[i:i+n-1]))
+        i += n
     end
 end
 
@@ -297,10 +402,16 @@ end
 Write a sequence of integers as fixed-width `i6` fields, 12 per line.
 
 """
-function _matxs_write_ints(io::IO,vals)
+function _matxs_write_ints(io::IO,vals; first_line::Int64=12, cont_line::Int64=12)
     fields = [@sprintf("%6d",Int(v)) for v in vals]
-    for i in 1:12:length(fields)
-        println(io,join(fields[i:min(i+11,length(fields))]))
+    i = 1
+    nfirst = min(first_line,length(fields))
+    println(io,join(fields[i:i+nfirst-1]))
+    i += nfirst
+    while i <= length(fields)
+        n = min(cont_line,length(fields)-i+1)
+        println(io,join(fields[i:i+n-1]))
+        i += n
     end
 end
 
@@ -310,9 +421,16 @@ end
 Write a sequence of hollerith identifiers as fixed-width `a8` fields, 8 per line.
 
 """
-function _matxs_write_holl(io::IO,names)
+function _matxs_write_holl(io::IO,names; first_prefix::String="", first_line::Int64=8,
+                           cont_line::Int64=8)
     fields = [rpad(first(n,8),8) for n in names]
-    for i in 1:8:length(fields)
-        println(io,join(fields[i:min(i+7,length(fields))]))
+    i = 1
+    nfirst = min(first_line,length(fields))
+    println(io,first_prefix*join(fields[i:i+nfirst-1]))
+    i += nfirst
+    while i <= length(fields)
+        n = min(cont_line,length(fields)-i+1)
+        println(io,join(fields[i:i+n-1]))
+        i += n
     end
 end

--- a/src/structures/Material.jl
+++ b/src/structures/Material.jl
@@ -273,7 +273,7 @@ julia> density = mat.get_density()
 ```
 """
 function get_density(this::Material)
-    if ismissing(density) error("Density is missing.") end
+    if ismissing(this.density) error("Density is missing.") end
     return this.density
 end
 


### PR DESCRIPTION
## Summary

This PR updates MATXS support to be suitable for use with Dragon.

## Changes

- Update MATXS reaction-name handling for photons, electrons, and positrons.
- Apply material-density normalization when reading and writing MATXS data.
- Fix `Material.get_density()` missing-density validation.
- Correct MATXS energy-boundary conversion between MeV and eV.
- Correct scattering-band indexing and ordering.

## Compatibility

Radiant-specific vectors are required for complete MATXS reconstruction. Standard-only MATXS files are rejected when required vectors are missing.
