### PR TITLE
Correction of an issue with bounds between soft and catastrophic coll…

### DIFF
--- a/src/cross_sections/bhabha.jl
+++ b/src/cross_sections/bhabha.jl
@@ -38,7 +38,8 @@ function bhabha(Zi::Real,Ei::Float64,W::Float64)
 end
 
 """
-    integrate_bhabha(Z::Int64,Ei::Float64,n::Int64,Wmin::Float64=1e-5,Wmax::Float64=Ei)
+    integrate_bhabha(Z::Int64,Ei::Float64,n::Int64,W⁻min::Float64=0.0,
+    is_subshells::Bool=true)
 
 Gives the integration of the Bhabha differential cross-sections multiplied by Wⁿ.
 
@@ -46,7 +47,8 @@ Gives the integration of the Bhabha differential cross-sections multiplied by W�
 - `Zi::Real` : number of electron(s).
 - `Ei::Float64` : incoming particle energy.
 - `n::Int64` : order of the energy-loss factor.
-- `E⁻min::Float64` : minimum energy of the knock-on electron.
+- `W⁻min::Float64` : minimum energy loss W of the incoming positron.
+- `is_subshells::Bool` : boolean indicating if bounded subshells are resolved.
 
 # Output Argument(s)
 - `σn::Float64` : integrated Bhabha cross-sections.
@@ -58,28 +60,28 @@ Gives the integration of the Bhabha differential cross-sections multiplied by W�
   electron transport used in Monte Carlo codes.
 
 """
-function integrate_bhabha(Z::Int64,Ei::Float64,n::Int64,E⁻min::Float64=0.0)
-  Nshells,Zi,Ui,_,_,_ = electron_subshells(Z)
+function integrate_bhabha(Z::Int64,Ei::Float64,n::Int64,W⁻min::Float64=0.0,is_subshells::Bool=true)
+  Nshells,Zi,Ui,_,_,_ = electron_subshells(Z,~is_subshells)
   σn = 0
   for δi in range(1,Nshells)
-      σn += Zi[δi] * integrate_bhabha_per_subshell(Z,Ei,n,Ui[δi],E⁻min)
+      σn += Zi[δi] * integrate_bhabha_per_subshell(Z,Ei,n,Ui[δi],W⁻min)
   end
   return σn
 end
 
 """
     integrate_bhabha_per_subshell(Z::Int64,Ei::Float64,n::Int64,Ui::Float64,
-    Wmin::Float64=1e-5,Wmax::Float64=Ei)
+    W⁻min::Float64=0.0)
 
 Gives the integration of the Bhabha differential cross-sections for an electron with a given
-binding energy, multiplied by Wⁿ.
+binding energy, multiplied by Wⁿ, over W ∈ [max(W⁻min,Ui),Ei].
 
 # Input Argument(s)
 - `Zi::Real` : number of electron(s).
 - `Ei::Float64` : incoming particle energy.
 - `n::Int64` : order of the energy-loss factor.
 - `Ui::Float64` : binding energy of the subshell.
-- `E⁻min::Float64` : minimum energy of the knock-on electron.
+- `W⁻min::Float64` : minimum energy loss W of the incoming positron.
 
 # Output Argument(s)
 - `σni::Float64` : integrated Bhabha cross-sections in a given subshell.
@@ -93,7 +95,7 @@ binding energy, multiplied by Wⁿ.
   electron transport used in Monte Carlo codes.
 
 """
-function integrate_bhabha_per_subshell(Z::Int64,Ei::Float64,n::Int64,Ui::Float64,E⁻min::Float64=0.0)
+function integrate_bhabha_per_subshell(Z::Int64,Ei::Float64,n::Int64,Ui::Float64,W⁻min::Float64=0.0)
 
     # Varibles
     rₑ = 2.81794092E-13       # (in cm)
@@ -108,7 +110,7 @@ function integrate_bhabha_per_subshell(Z::Int64,Ei::Float64,n::Int64,Ui::Float64
     # Compute the Bhabha cross-section per subshell
     σni = 0
     W⁺ = Ei
-    W⁻ = E⁻min+Ui
+    W⁻ = max(W⁻min,Ui)
     if W⁺ > W⁻
         if n == 0
           J₀(W) = -1/W - b1*log(W)/Ei + b2*W/Ei^2 - b3*W^2/(2*Ei^3) + b4*W^3/(3*Ei^4)

--- a/src/cross_sections/inelastic_collision_heavy_particle.jl
+++ b/src/cross_sections/inelastic_collision_heavy_particle.jl
@@ -282,7 +282,7 @@ end
 
 """
     integrate_inelastic_collision_heavy_particle(Z::Int64, Ei::Float64, n::Int64,
-    particle::Particle, E⁻min::Float64=0.0)
+    particle::Particle, W⁻min::Float64=0.0, is_subshells::Bool=true)
 
 Computes the subshell-summed analytical energy-loss moment of the heavy-particle
 inelastic collision cross-section for one element.
@@ -292,23 +292,24 @@ inelastic collision cross-section for one element.
 - `Ei::Float64` : incoming particle energy [in m_e*c^2].
 - `n::Int64` : energy-loss moment order, either 0 or 1.
 - `particle::Particle` : incoming heavy charged particle.
-- `E⁻min::Float64=0.0` : lower cutoff for the transferred energy [in m_e*c^2].
+- `W⁻min::Float64=0.0` : minimum energy loss W of the incoming particle [in m_e*c^2].
+- `is_subshells::Bool=true` : boolean indicating if bounded subshells are resolved.
 
 # Output Argument(s)
 - `σn::Float64` : analytical moment summed over all subshells.
 """
-function integrate_inelastic_collision_heavy_particle(Z::Int64,Ei::Float64,n::Int64,particle::Particle,E⁻min::Float64=0.0)
-    Nshells,Zi,Ui,_,_,_ = electron_subshells(Z)
+function integrate_inelastic_collision_heavy_particle(Z::Int64,Ei::Float64,n::Int64,particle::Particle,W⁻min::Float64=0.0,is_subshells::Bool=true)
+    Nshells,Zi,Ui,_,_,_ = electron_subshells(Z,~is_subshells)
     σn = 0
     for δi in range(1,Nshells)
-        σn += Zi[δi] * integrate_inelastic_collision_heavy_particle_per_subshell(Ei,n,Ui[δi],particle,E⁻min)
+        σn += Zi[δi] * integrate_inelastic_collision_heavy_particle_per_subshell(Ei,n,Ui[δi],particle,W⁻min)
     end
     return σn
 end
 
 """
     integrate_inelastic_collision_heavy_particle_per_subshell(Ei::Float64, n::Int64,
-    Ui::Float64, particle::Particle, E⁻min::Float64=0.0)
+    Ui::Float64, particle::Particle, W⁻min::Float64=0.0)
 
 Computes the analytical energy-loss moment of the heavy-particle inelastic collision
 cross-section for one subshell.
@@ -318,12 +319,12 @@ cross-section for one subshell.
 - `n::Int64` : energy-loss moment order, either 0 or 1.
 - `Ui::Float64` : subshell binding energy [in m_e*c^2].
 - `particle::Particle` : incoming heavy charged particle.
-- `E⁻min::Float64=0.0` : lower cutoff for the transferred energy [in m_e*c^2].
+- `W⁻min::Float64=0.0` : minimum energy loss W of the incoming particle [in m_e*c^2].
 
 # Output Argument(s)
 - `σni::Float64` : analytical moment for the subshell.
 """
-function integrate_inelastic_collision_heavy_particle_per_subshell(Ei::Float64,n::Int64,Ui::Float64,particle::Particle,E⁻min::Float64=0.0)
+function integrate_inelastic_collision_heavy_particle_per_subshell(Ei::Float64,n::Int64,Ui::Float64,particle::Particle,W⁻min::Float64=0.0)
 
     #----
     # Initialization
@@ -342,7 +343,7 @@ function integrate_inelastic_collision_heavy_particle_per_subshell(Ei::Float64,n
     #----
     σni = 0
     W⁺ = min(Ei,W_ridge)
-    W⁻ = max(E⁻min,Ui)
+    W⁻ = max(W⁻min,Ui)
     if W⁺ > W⁻
         ΔW = W⁺ - W⁻
         if n == 0

--- a/src/cross_sections/moller.jl
+++ b/src/cross_sections/moller.jl
@@ -41,8 +41,9 @@ function moller(Zi::Real,Ei::Float64,W::Float64,Ui::Float64=0.0,Ti::Float64=0.0,
 end
 
 """
-    integrate_moller(Z::Int64,Ei::Float64,n::Int64,Wmin::Float64=1e-5,Wmax::Float64=Ei,
-    is_focusing_møller::Bool=false,is_hydrogenic_distribution_term::Bool=false)
+    integrate_moller(Z::Int64,Ei::Float64,n::Int64,W⁻min::Float64=0.0,
+    is_focusing_møller::Bool=false,is_hydrogenic_distribution_term::Bool=false,
+    is_subshells::Bool=true)
 
 Gives the integration of the Møller differential cross-sections multiplied by Wⁿ.
 
@@ -50,10 +51,11 @@ Gives the integration of the Møller differential cross-sections multiplied by W
 - `Zi::Real` : number of electron(s).
 - `Ei::Float64` : incoming particle energy.
 - `n::Int64` : order of the energy-loss factor.
-- `E⁻min::Float64` : minimum energy of the knock-on electron.
+- `W⁻min::Float64` : minimum energy loss W of the incoming electron.
 - `is_focusing_møller::Bool` : boolean to enable or not the focusing term.
 - `is_hydrogenic_distribution_term::Bool`: boolean to enable or not the hydrogenic
   distribution term.
+- `is_subshells::Bool` : boolean indicating if bounded subshells are resolved.
 
 # Output Argument(s)
 - `σn::Float64` : integrated Møller cross-sections.
@@ -67,21 +69,22 @@ Gives the integration of the Møller differential cross-sections multiplied by W
   electron transport used in Monte Carlo codes.
 
 """
-function integrate_moller(Z::Int64,Ei::Float64,n::Int64,E⁻min::Float64=0.0,is_focusing_møller::Bool=false,is_hydrogenic_distribution_term::Bool=false)
-    Nshells,Zi,Ui,Ti,_,_ = electron_subshells(Z)
+function integrate_moller(Z::Int64,Ei::Float64,n::Int64,W⁻min::Float64=0.0,is_focusing_møller::Bool=false,is_hydrogenic_distribution_term::Bool=false,is_subshells::Bool=true)
+    Nshells,Zi,Ui,Ti,_,_ = electron_subshells(Z,~is_subshells)
     σn = 0
     for δi in range(1,Nshells)
-        σn += Zi[δi] * integrate_moller_per_subshell(Ei,n,Ui[δi],Ti[δi],E⁻min,is_focusing_møller,is_hydrogenic_distribution_term)
+        σn += Zi[δi] * integrate_moller_per_subshell(Ei,n,Ui[δi],Ti[δi],W⁻min,is_focusing_møller,is_hydrogenic_distribution_term)
     end
     return σn
 end
 
 """
     integrate_moller_per_subshell(Ei::Float64,n::Int64,Ui::Float64=0.0,Ti::Float64=0.0,
-    Wmin::Float64=Ui,Wmax::Float64=Ei/2,is_focusing_møller::Bool=false)
+    W⁻min::Float64=0.0,is_focusing_møller::Bool=false,
+    is_hydrogenic_distribution_term::Bool=false)
 
 Gives the integration of the Møller differential cross-sections for an electron with a given
-binding energy, multiplied by (W+Ui)ⁿ.
+binding energy, multiplied by Wⁿ, over W ∈ [max(W⁻min,Ui),(Ei+Ui)/2].
 
 # Input Argument(s)
 - `Zi::Real` : number of electron(s).
@@ -89,7 +92,7 @@ binding energy, multiplied by (W+Ui)ⁿ.
 - `n::Int64` : order of the energy-loss factor.
 - `Ui::Float64` : binding energy of the subshell.
 - `Ti::Vector{Float64}`: mean kinetic energy per subshell.
-- `E⁻min::Float64` : minimum energy of the knock-on electron.
+- `W⁻min::Float64` : minimum energy loss W of the incoming electron.
 - `is_focusing_møller::Bool` : boolean to enable or not the focusing term.
 - `is_hydrogenic_distribution_term::Bool`: boolean to enable or not the hydrogenic
   distribution term.
@@ -106,7 +109,7 @@ binding energy, multiplied by (W+Ui)ⁿ.
   electron transport used in Monte Carlo codes.
 
 """
-function integrate_moller_per_subshell(Ei::Float64,n::Int64,Ui::Float64=0.0,Ti::Float64=0.0,E⁻min::Float64=0.0,is_focusing_møller::Bool=false,is_hydrogenic_distribution_term::Bool=false)
+function integrate_moller_per_subshell(Ei::Float64,n::Int64,Ui::Float64=0.0,Ti::Float64=0.0,W⁻min::Float64=0.0,is_focusing_møller::Bool=false,is_hydrogenic_distribution_term::Bool=false)
 
     # Varibles
     rₑ = 2.81794092E-13       # (in cm)
@@ -116,9 +119,9 @@ function integrate_moller_per_subshell(Ei::Float64,n::Int64,Ui::Float64=0.0,Ti::
     # Compute the Møller cross-section per subshell
     σni = 0
     W⁺ = (Ei+Ui)/2
-    W⁻ = E⁻min+Ui
+    W⁻ = max(W⁻min,Ui)
     if W⁺ > W⁻
-        if (is_hydrogenic_distribution_term) G = integrate_moller_hydrogenic_distribution_term(n,Ei,Ui,Ti,E⁻min) else G = 0 end
+        if (is_hydrogenic_distribution_term) G = integrate_moller_hydrogenic_distribution_term(n,Ei,Ui,Ti,W⁻min) else G = 0 end
         if n == 0
             J₀(W) = -1/W + 1/(Ei-W+Ui) +  W/(Ei+1)^2 + (2*Ei+1)/((Ei+1)^2*(Ei+Ui))*(log(Ei-W+Ui)-log(W))
             σni += (J₀(W⁺) - J₀(W⁻)) + G
@@ -219,9 +222,9 @@ end
 
 """
     integrate_moller_hydrogenic_distribution_term(n::Int64,Ei::Float64,Ui::Float64,
-    Ti::Float64,E⁻min::Float64=0.0)
+    Ti::Float64,W⁻min::Float64=0.0)
 
-Gives the integrated Møller term accounting for the isotropic hydrogenic distribution of 
+Gives the integrated Møller term accounting for the isotropic hydrogenic distribution of
 orbital electron velocities, multiplied by Wⁿ.
 
 # Input Argument(s)
@@ -229,7 +232,7 @@ orbital electron velocities, multiplied by Wⁿ.
 - `W::Float64` : energy lost by the incoming electron.
 - `Ui::Float64`: binding energy per subshell.
 - `Ti::Float64`: mean kinetic energy per subshell.
-- `E⁻min::Float64` : minimum energy of the knock-on electron.
+- `W⁻min::Float64` : minimum energy loss W of the incoming electron.
 
 # Output Argument(s)
 - `Gi::Float64` : integrated Møller term accounting for the isotropic hydrogenic
@@ -241,10 +244,10 @@ orbital electron velocities, multiplied by Wⁿ.
 - Perkins (1989), The Livermore electron impact ionization data base.
 
 """
-function integrate_moller_hydrogenic_distribution_term(n::Int64,Ei::Float64,Ui::Float64,Ti::Float64,E⁻min::Float64=0.0)
+function integrate_moller_hydrogenic_distribution_term(n::Int64,Ei::Float64,Ui::Float64,Ti::Float64,W⁻min::Float64=0.0)
 	Gi = 0
 	W⁺ = (Ei+Ui)/2
-    W⁻ = E⁻min+Ui
+    W⁻ = max(W⁻min,Ui)
     if W⁺ > W⁻
 		if n == 0
             if abs(Ui-Ti) ≤ 1e-7

--- a/src/structures/Inelastic_Collision.jl
+++ b/src/structures/Inelastic_Collision.jl
@@ -415,11 +415,11 @@ function tcs(this::Inelastic_Collision,Ei::Float64,Ec::Float64,particle::Particl
     # Close collisions
     #----
     if is_electron(particle)
-        σt += integrate_moller(Z,Ei,0,Ei-Ec,this.is_focusing_møller,this.is_hydrogenic_distribution_term)
+        σt += integrate_moller(Z,Ei,0,Ei-Ec,this.is_focusing_møller,this.is_hydrogenic_distribution_term,this.is_subshells_dependant)
     elseif is_positron(particle)
-        σt += integrate_bhabha(Z,Ei,0,Ei-Ec)
+        σt += integrate_bhabha(Z,Ei,0,Ei-Ec,this.is_subshells_dependant)
     elseif is_proton(particle) || is_alpha(particle)
-        σt += integrate_inelastic_collision_heavy_particle(Z,Ei,0,particle,Ei-Ec)
+        σt += integrate_inelastic_collision_heavy_particle(Z,Ei,0,particle,Ei-Ec,this.is_subshells_dependant)
     else
         error("Unknown particle")
     end
@@ -450,9 +450,9 @@ function acs(this::Inelastic_Collision,Ei::Float64,Ec::Float64,particle::Particl
     # Close collisions
     #----
     if is_electron(particle)
-        σa = integrate_moller(Z,Ei,0,Ei-min(Ec,Ecutoff),this.is_focusing_møller,this.is_hydrogenic_distribution_term)
+        σa = integrate_moller(Z,Ei,0,Ei-min(Ec,Ecutoff),this.is_focusing_møller,this.is_hydrogenic_distribution_term,this.is_subshells_dependant)
     elseif is_positron(particle)
-        σa = integrate_bhabha(Z,Ei,0,Ei-min(Ec,Ecutoff))
+        σa = integrate_bhabha(Z,Ei,0,Ei-min(Ec,Ecutoff),this.is_subshells_dependant)
     else
         error("Unknown particle")
     end
@@ -488,7 +488,7 @@ Gives the stopping power for inelastic collision interaction.
 function sp(this::Inelastic_Collision,Z::Vector{Int64},ωz::Vector{Float64},atz::Vector{Float64},ρ::Float64,N_density::Float64,state_of_matter::String,Ei::Float64,Ec::Float64,particle::Particle,I_eff::Float64=NaN,atomic_weights::Union{Nothing,Vector{Float64}}=nothing)
 
     # Compute the total stopping power
-    Stot = bethe(Z,ωz,ρ,Ei,particle,this.density_correction,state_of_matter,I_eff; atomic_weights=atomic_weights)
+    Stot = bethe(Z,ωz,ρ,Ei,particle,this.density_correction,state_of_matter,I_eff; atomic_weights=atomic_weights,is_shell_correction=this.is_shell_correction)
 
     # Compute the catastrophic Møller- or Bhabha- derived stopping power
     Sc = 0
@@ -497,11 +497,11 @@ function sp(this::Inelastic_Collision,Z::Vector{Int64},ωz::Vector{Float64},atz:
 
         # Close collision
         if is_electron(particle)
-            Sc += atz[i] * N_density * integrate_moller(Z[i],Ei,1,Ei-Ec,this.is_focusing_møller,this.is_hydrogenic_distribution_term)
+            Sc += atz[i] * N_density * integrate_moller(Z[i],Ei,1,Ei-Ec,this.is_focusing_møller,this.is_hydrogenic_distribution_term,this.is_subshells_dependant)
         elseif is_positron(particle)
-            Sc += atz[i] * N_density * integrate_bhabha(Z[i],Ei,1,Ei-Ec)
+            Sc += atz[i] * N_density * integrate_bhabha(Z[i],Ei,1,Ei-Ec,this.is_subshells_dependant)
         elseif is_proton(particle) || is_alpha(particle)
-            Sc += atz[i] * N_density * integrate_inelastic_collision_heavy_particle(Z[i],Ei,1,particle,Ei-Ec)
+            Sc += atz[i] * N_density * integrate_inelastic_collision_heavy_particle(Z[i],Ei,1,particle,Ei-Ec,this.is_subshells_dependant)
         end
     end
 


### PR DESCRIPTION
…isions in the inelastic model for electron and positron. There was an incoherence, which increases the bounds by the binding energy, having an impact on total and energy deposition cross-sections, as well as restricted stopping powers. [patch]